### PR TITLE
feat: バルク登録対応のためレートリミットのデフォルト値を緩和

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,8 +148,8 @@ const entity = await upsertEntity({
 | Variable          | Description                         | Default    |
 | ----------------- | ----------------------------------- | ---------- |
 | `PCE_DB`          | DuckDB file path                    | `:memory:` |
-| `PCE_RATE_CAP`    | Rate limit per bucket               | `100`      |
-| `PCE_RATE_WINDOW` | Rate window (seconds)               | `60`       |
+| `PCE_RATE_CAP`    | Rate limit per bucket               | `1000`     |
+| `PCE_RATE_WINDOW` | Rate window (seconds)               | `10`       |
 | `PCE_TOKEN`       | Auth token (required in production) | -          |
 
 ## Quality Gates

--- a/apps/pce-memory/src/store/rate.ts
+++ b/apps/pce-memory/src/store/rate.ts
@@ -2,14 +2,22 @@ import { getConnection } from '../db/connection.js';
 
 const DEFAULT_BUCKETS = ['tool', 'policy', 'activate'];
 
+/**
+ * レート制限の上限値を取得
+ * デフォルト: 1000件/10秒（バルク登録に対応するため緩和）
+ */
 function cap(): number {
   const envCap = Number(process.env['PCE_RATE_CAP'] ?? '');
-  return Number.isFinite(envCap) && envCap > 0 ? envCap : 100;
+  return Number.isFinite(envCap) && envCap > 0 ? envCap : 1000;
 }
 
+/**
+ * レート制限の時間窓（秒）を取得
+ * デフォルト: 10秒（短い窓で頻繁にリセットし、一時的な制限からの回復を早める）
+ */
 function windowSec(): number {
   const envWin = Number(process.env['PCE_RATE_WINDOW'] ?? '');
-  return Number.isFinite(envWin) && envWin >= 0 ? envWin : 60; // seconds
+  return Number.isFinite(envWin) && envWin >= 0 ? envWin : 10; // seconds
 }
 
 /**


### PR DESCRIPTION
## Summary

- レートリミットのデフォルト値を緩和し、バルク初期登録ユースケースに対応
- `PCE_RATE_CAP`: 100 → 1000（10倍に増加）
- `PCE_RATE_WINDOW`: 60秒 → 10秒（短縮）

## 背景

プロジェクト開始時に大量の知識を一括登録する際、従来の設定（100件/60秒）ではすぐにレートリミットに達し、解除まで長時間待つ必要があった。

## 効果

- 10秒あたり1000件 → 1分あたり6000件相当の操作が可能
- 時間窓が短いため、一時的に制限に達しても10秒で回復
- 環境変数で従来値（`PCE_RATE_CAP=100`, `PCE_RATE_WINDOW=60`）に戻すことも可能

## Test plan

- [x] 全416テスト通過
- [x] 型チェック通過
- [ ] バルク登録シナリオで制限緩和を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)