### PR TITLE
fix(prompts): prompt名をアンダースコアに変更

### DIFF
--- a/apps/pce-memory/src/core/handlers.ts
+++ b/apps/pce-memory/src/core/handlers.ts
@@ -1475,7 +1475,7 @@ export interface PromptMessage {
  */
 export const PROMPTS_DEFINITIONS: PromptDefinition[] = [
   {
-    name: 'recall-context',
+    name: 'recall_context',
     description: 'タスク開始時に関連知識を想起するためのガイド',
     arguments: [
       {
@@ -1491,7 +1491,7 @@ export const PROMPTS_DEFINITIONS: PromptDefinition[] = [
     ],
   },
   {
-    name: 'record-decision',
+    name: 'record_decision',
     description: '設計決定を記録するためのガイド',
     arguments: [
       {
@@ -1502,7 +1502,7 @@ export const PROMPTS_DEFINITIONS: PromptDefinition[] = [
     ],
   },
   {
-    name: 'sync-workflow',
+    name: 'sync_workflow',
     description: 'Git同期ワークフローのガイド（push/pull/status）',
     arguments: [
       {
@@ -1513,7 +1513,7 @@ export const PROMPTS_DEFINITIONS: PromptDefinition[] = [
     ],
   },
   {
-    name: 'debug-assist',
+    name: 'debug_assist',
     description: 'デバッグ時に関連知識を検索するためのガイド',
     arguments: [
       {
@@ -1533,7 +1533,7 @@ function generatePromptMessages(
   args?: Record<string, string>
 ): PromptMessage[] {
   switch (prompt.name) {
-    case 'recall-context': {
+    case 'recall_context': {
       const query = args?.['query'] || '<検索したいキーワード>';
       const scope = args?.['scope'] || 'project';
       return [
@@ -1578,7 +1578,7 @@ function generatePromptMessages(
       ];
     }
 
-    case 'record-decision': {
+    case 'record_decision': {
       const topic = args?.['topic'] || '<決定のトピック>';
       return [
         {
@@ -1632,7 +1632,7 @@ function generatePromptMessages(
       ];
     }
 
-    case 'sync-workflow': {
+    case 'sync_workflow': {
       const operation = args?.['operation'] || 'status';
       const operationGuides: Record<string, string> = {
         push: `## Push: ローカル知識のエクスポート
@@ -1739,7 +1739,7 @@ export PCE_SYNC_ENABLED=true
       ];
     }
 
-    case 'debug-assist': {
+    case 'debug_assist': {
       const errorMessage = args?.['error_message'] || '<エラーメッセージ>';
       return [
         {

--- a/apps/pce-memory/test/prompts.test.ts
+++ b/apps/pce-memory/test/prompts.test.ts
@@ -24,10 +24,10 @@ describe('MCP Prompts (Issue #16)', () => {
 
     it('期待されるPromptが含まれている', () => {
       const names = PROMPTS_DEFINITIONS.map((p) => p.name);
-      expect(names).toContain('recall-context');
-      expect(names).toContain('record-decision');
-      expect(names).toContain('sync-workflow');
-      expect(names).toContain('debug-assist');
+      expect(names).toContain('recall_context');
+      expect(names).toContain('record_decision');
+      expect(names).toContain('sync_workflow');
+      expect(names).toContain('debug_assist');
     });
   });
 
@@ -51,14 +51,14 @@ describe('MCP Prompts (Issue #16)', () => {
 
   describe('handleGetPrompt', () => {
     it('存在するPromptを取得できる', async () => {
-      const result = await handleGetPrompt({ name: 'recall-context' });
+      const result = await handleGetPrompt({ name: 'recall_context' });
       expect(result.description).toBeDefined();
       expect(result.messages).toBeDefined();
       expect(result.messages.length).toBeGreaterThan(0);
     });
 
     it('メッセージにroleとcontentがある', async () => {
-      const result = await handleGetPrompt({ name: 'recall-context' });
+      const result = await handleGetPrompt({ name: 'recall_context' });
       for (const msg of result.messages) {
         expect(msg.role).toMatch(/^(user|assistant)$/);
         expect(msg.content).toBeDefined();
@@ -69,7 +69,7 @@ describe('MCP Prompts (Issue #16)', () => {
 
     it('引数を渡すとメッセージに反映される', async () => {
       const result = await handleGetPrompt({
-        name: 'recall-context',
+        name: 'recall_context',
         arguments: { query: 'JWT認証', scope: 'project' },
       });
       // 引数がメッセージに含まれることを確認
@@ -89,14 +89,14 @@ describe('MCP Prompts (Issue #16)', () => {
 
     it('必須引数がない場合エラーを投げる', async () => {
       // record-decisionのtopicは必須
-      await expect(handleGetPrompt({ name: 'record-decision' })).rejects.toThrow(
+      await expect(handleGetPrompt({ name: 'record_decision' })).rejects.toThrow(
         'Required argument missing: topic'
       );
     });
 
     it('必須引数を渡すと成功する', async () => {
       const result = await handleGetPrompt({
-        name: 'record-decision',
+        name: 'record_decision',
         arguments: { topic: '状態管理ライブラリ選定' },
       });
       expect(result.messages.length).toBeGreaterThan(0);
@@ -107,7 +107,7 @@ describe('MCP Prompts (Issue #16)', () => {
 
   describe('sync-workflow prompt', () => {
     it('operationなしでデフォルトガイドを返す', async () => {
-      const result = await handleGetPrompt({ name: 'sync-workflow' });
+      const result = await handleGetPrompt({ name: 'sync_workflow' });
       expect(result.messages.length).toBeGreaterThan(0);
       const allText = result.messages.map((m) => m.content.text).join(' ');
       // statusがデフォルト
@@ -116,7 +116,7 @@ describe('MCP Prompts (Issue #16)', () => {
 
     it('operation=pushでpushガイドを返す', async () => {
       const result = await handleGetPrompt({
-        name: 'sync-workflow',
+        name: 'sync_workflow',
         arguments: { operation: 'push' },
       });
       const allText = result.messages.map((m) => m.content.text).join(' ');
@@ -126,7 +126,7 @@ describe('MCP Prompts (Issue #16)', () => {
 
     it('operation=pullでpullガイドを返す', async () => {
       const result = await handleGetPrompt({
-        name: 'sync-workflow',
+        name: 'sync_workflow',
         arguments: { operation: 'pull' },
       });
       const allText = result.messages.map((m) => m.content.text).join(' ');
@@ -138,7 +138,7 @@ describe('MCP Prompts (Issue #16)', () => {
   describe('debug-assist prompt', () => {
     it('エラーメッセージを引数で渡せる', async () => {
       const result = await handleGetPrompt({
-        name: 'debug-assist',
+        name: 'debug_assist',
         arguments: { error_message: 'ECONNREFUSED' },
       });
       const allText = result.messages.map((m) => m.content.text).join(' ');


### PR DESCRIPTION
## Summary

Claude Codeのスラッシュコマンドとの互換性のため、prompt名のハイフンをアンダースコアに変更しました。

| Before | After |
|--------|-------|
| `recall-context` | `recall_context` |
| `record-decision` | `record_decision` |
| `sync-workflow` | `sync_workflow` |
| `debug-assist` | `debug_assist` |

## 背景

Claude Codeのスラッシュコマンド形式は `/mcp__<server>__<prompt>` であり、ハイフンが含まれると正しく認識されない可能性がありました。

## Test plan

- [x] prompts.test.ts 全テストパス
- [x] typecheck成功
- [x] lint成功
- [x] build成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)