### PR TITLE
chore(gitignore): ignore .serena and local tgz artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ Thumbs.db
 .idea/
 *.sublime-*
 *.code-workspace
+.serena/
 
 # Environment variables
 .env
@@ -44,6 +45,9 @@ Thumbs.db
 .env.development.local
 .env.test.local
 .env.production.local
+
+# Local artifacts
+apps/pce-memory/pce-memory-*.tgz
 
 # DuckDB
 *.db


### PR DESCRIPTION
## Why
- `.serena/` is a local tooling artifact.
- `apps/pce-memory/pce-memory-*.tgz` is a local build/package artifact.

These should not be tracked and can cause noise in `git status` and CI formatting checks.

## Changes
- Add `.serena/` and `apps/pce-memory/pce-memory-*.tgz` to `.gitignore`.
