### PR TITLE
refactor(tools)!: MCPツール名をドット区切りからアンダースコア区切りに変更

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 
 ## いつ activate するか
 
-以下の状況で `pce.memory.activate` を呼び出してください：
+以下の状況で `pce_memory_activate` を呼び出してください：
 
 - **新しいタスクを開始するとき** - 関連する過去の決定を確認
 - **設計判断が必要なとき** - 既存のアーキテクチャ決定を参照
@@ -38,7 +38,7 @@
 
 ## いつ upsert するか
 
-以下の情報を `pce.memory.upsert` で記録してください：
+以下の情報を `pce_memory_upsert` で記録してください：
 
 ### kind: fact（事実）
 
@@ -103,7 +103,7 @@
 
 ## feedback を送るタイミング
 
-activateで取得した知識が役立ったかを `pce.memory.feedback` で報告してください：
+activateで取得した知識が役立ったかを `pce_memory_feedback` で報告してください：
 
 | signal      | いつ送るか                                |
 | ----------- | ----------------------------------------- |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,14 +94,14 @@ Uninitialized → PolicyApplied → HasClaims → Ready
 
 | Tool                           | Description                                        |
 | ------------------------------ | -------------------------------------------------- |
-| `pce.memory.policy.apply`      | Apply policy (initialization)                      |
-| `pce.memory.upsert`            | Register claim with entities/relations             |
-| `pce.memory.upsert.entity`     | Register graph entity                              |
-| `pce.memory.upsert.relation`   | Register graph relation                            |
-| `pce.memory.activate`          | Build active context (hybrid search)               |
-| `pce.memory.feedback`          | Update critic (helpful/harmful/outdated/duplicate) |
-| `pce.memory.boundary.validate` | Pre-generation boundary check                      |
-| `pce.memory.state`             | Get current state                                  |
+| `pce_memory_policy_apply`      | Apply policy (initialization)                      |
+| `pce_memory_upsert`            | Register claim with entities/relations             |
+| `pce_memory_upsert_entity`     | Register graph entity                              |
+| `pce_memory_upsert_relation`   | Register graph relation                            |
+| `pce_memory_activate`          | Build active context (hybrid search)               |
+| `pce_memory_feedback`          | Update critic (helpful/harmful/outdated/duplicate) |
+| `pce_memory_boundary_validate` | Pre-generation boundary check                      |
+| `pce_memory_state`             | Get current state                                  |
 
 ## Testing Approach
 

--- a/README.md
+++ b/README.md
@@ -96,17 +96,17 @@ PCE Memoryは以下のMCPツールを提供します：
 
 | Tool                           | Description                                     |
 | ------------------------------ | ----------------------------------------------- |
-| `pce.memory.policy.apply`      | ポリシー適用 (boundary/retrieval設定)           |
-| `pce.memory.observe`           | 観察を記録 (Observation → Claims)               |
-| `pce.memory.upsert`            | Claimを登録 (Long-term memory)                  |
-| `pce.memory.activate`          | Active Contextを構成 (Query → AC)               |
-| `pce.memory.boundary.validate` | 境界チェック / redact-before-send               |
-| `pce.memory.feedback`          | フィードバックを送信 (helpful/harmful/outdated) |
-| `pce.memory.state`             | 状態情報を取得 (state/policy_version)           |
+| `pce_memory_policy_apply`      | ポリシー適用 (boundary/retrieval設定)           |
+| `pce_memory_observe`           | 観察を記録 (Observation → Claims)               |
+| `pce_memory_upsert`            | Claimを登録 (Long-term memory)                  |
+| `pce_memory_activate`          | Active Contextを構成 (Query → AC)               |
+| `pce_memory_boundary_validate` | 境界チェック / redact-before-send               |
+| `pce_memory_feedback`          | フィードバックを送信 (helpful/harmful/outdated) |
+| `pce_memory_state`             | 状態情報を取得 (state/policy_version)           |
 
 詳細は [docs/mcp-tools.md](docs/mcp-tools.md) を参照してください。
 
-### Observation（`pce.memory.observe`）の保持とセキュリティ（要点）
+### Observation（`pce_memory_observe`）の保持とセキュリティ（要点）
 
 - Observation は短期TTLで保持し、期限後は `content` をスクラブ（NULL化）する運用を推奨します。
 - `PCE_OBS_TTL_DAYS` / `PCE_OBS_TTL_DAYS_MAX` で TTL を調整できます。

--- a/apps/pce-memory/CHANGELOG.md
+++ b/apps/pce-memory/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **BREAKING: Rename all MCP tool names from dot notation to underscore notation** - Following MCP community standard (snake_case)
+  - `pce.memory.policy.apply` → `pce_memory_policy_apply`
+  - `pce.memory.observe` → `pce_memory_observe`
+  - `pce.memory.upsert` → `pce_memory_upsert`
+  - `pce.memory.activate` → `pce_memory_activate`
+  - `pce.memory.boundary.validate` → `pce_memory_boundary_validate`
+  - `pce.memory.feedback` → `pce_memory_feedback`
+  - `pce.memory.state` → `pce_memory_state`
+  - `pce.memory.upsert.entity` → `pce_memory_upsert_entity`
+  - `pce.memory.upsert.relation` → `pce_memory_upsert_relation`
+  - `pce.memory.query.entity` → `pce_memory_query_entity`
+  - `pce.memory.query.relation` → `pce_memory_query_relation`
+  - `pce.memory.sync.push` → `pce_memory_sync_push`
+  - `pce.memory.sync.pull` → `pce_memory_sync_pull`
+  - `pce.memory.sync.status` → `pce_memory_sync_status`
+  - Clients must update tool invocations to use new names
+  - See [SEP-986](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/986) for MCP naming conventions
+
 ## [0.9.1] - 2025-12-18
 
 ### Fixed

--- a/apps/pce-memory/scripts/assay/pce-adapter.ts
+++ b/apps/pce-memory/scripts/assay/pce-adapter.ts
@@ -124,14 +124,14 @@ export class PceMemorySearchAdapter implements SearchAdapter<PceQuery, Metrics> 
 
     // ポリシー適用
     console.log('📋 Applying policy...');
-    await this.callTool('pce.memory.policy.apply', {
+    await this.callTool('pce_memory_policy_apply', {
       policy: TEST_POLICY,
     });
 
     // テストデータ投入
     console.log(`📝 Upserting ${TEST_CLAIMS.length} test claims...`);
     for (const claim of TEST_CLAIMS) {
-      const result = await this.callTool('pce.memory.upsert', claim);
+      const result = await this.callTool('pce_memory_upsert', claim);
       // テストIDと生成されたclaim IDのマッピングを保存
       if (result && typeof result === 'object' && 'id' in result) {
         const generatedId = (result as { id: string }).id;
@@ -143,7 +143,7 @@ export class PceMemorySearchAdapter implements SearchAdapter<PceQuery, Metrics> 
   }
 
   /**
-   * クエリ実行: pce.memory.activateを呼び出しメトリクスを計算
+   * クエリ実行: pce_memory_activateを呼び出しメトリクスを計算
    */
   async execute(query: PceQuery, ctx: SearchAdapterContext): Promise<Metrics> {
     const startTime = Date.now();
@@ -153,7 +153,7 @@ export class PceMemorySearchAdapter implements SearchAdapter<PceQuery, Metrics> 
     }
 
     try {
-      const result = await this.callTool('pce.memory.activate', {
+      const result = await this.callTool('pce_memory_activate', {
         q: query.text,
         scope: ['session', 'project', 'principle'],
         allow: ['answer:task'],

--- a/apps/pce-memory/scripts/assay/run-observe-evaluation.ts
+++ b/apps/pce-memory/scripts/assay/run-observe-evaluation.ts
@@ -2,7 +2,7 @@
 /**
  * Observe機能評価スクリプト
  *
- * pce.memory.observe の機能テストを実行し、結果をレポートする。
+ * pce_memory_observe の機能テストを実行し、結果をレポートする。
  * assay-kitとは独立した評価スクリプト。
  *
  * 使用方法:
@@ -133,7 +133,7 @@ async function runTestCase(
 
   try {
     // observe実行
-    const observeResult = await runner.callTool('pce.memory.observe', testCase.input);
+    const observeResult = await runner.callTool('pce_memory_observe', testCase.input);
     const duration = Date.now() - startTime;
 
     // 期待値の検証
@@ -217,7 +217,7 @@ async function runTestCase(
       Array.isArray(observeResult.claim_ids) &&
       observeResult.claim_ids.length > 0
     ) {
-      const activateResult = await runner.callTool('pce.memory.activate', {
+      const activateResult = await runner.callTool('pce_memory_activate', {
         scope: ['session'],
         allow: ['answer:task'],
         include_meta: true,
@@ -294,7 +294,7 @@ async function main() {
 
     // ポリシー適用
     console.log('📋 Applying policy...');
-    await runner.callTool('pce.memory.policy.apply', {});
+    await runner.callTool('pce_memory_policy_apply', {});
 
     console.log('✅ Server ready\n');
 

--- a/apps/pce-memory/src/core/handlers.ts
+++ b/apps/pce-memory/src/core/handlers.ts
@@ -1889,34 +1889,34 @@ export async function dispatchTool(
   args: Record<string, unknown>
 ): Promise<ToolResult> {
   switch (name) {
-    case 'pce.memory.policy.apply':
+    case 'pce_memory_policy_apply':
       return handlePolicyApply(args);
-    case 'pce.memory.observe':
+    case 'pce_memory_observe':
       return handleObserve(args);
-    case 'pce.memory.upsert':
+    case 'pce_memory_upsert':
       return handleUpsert(args);
-    case 'pce.memory.upsert.entity':
+    case 'pce_memory_upsert_entity':
       return handleUpsertEntity(args);
-    case 'pce.memory.upsert.relation':
+    case 'pce_memory_upsert_relation':
       return handleUpsertRelation(args);
-    case 'pce.memory.query.entity':
+    case 'pce_memory_query_entity':
       return handleQueryEntity(args);
-    case 'pce.memory.query.relation':
+    case 'pce_memory_query_relation':
       return handleQueryRelation(args);
-    case 'pce.memory.activate':
+    case 'pce_memory_activate':
       return handleActivate(args);
-    case 'pce.memory.boundary.validate':
+    case 'pce_memory_boundary_validate':
       return handleBoundaryValidate(args);
-    case 'pce.memory.feedback':
+    case 'pce_memory_feedback':
       return handleFeedback(args);
-    case 'pce.memory.state':
+    case 'pce_memory_state':
       return handleGetState(args);
     // Sync Tools (Issue #18)
-    case 'pce.memory.sync.push':
+    case 'pce_memory_sync_push':
       return handleSyncPush(args);
-    case 'pce.memory.sync.pull':
+    case 'pce_memory_sync_pull':
       return handleSyncPull(args);
-    case 'pce.memory.sync.status':
+    case 'pce_memory_sync_status':
       return handleSyncStatus(args);
     default:
       return createToolResult(
@@ -2062,7 +2062,7 @@ function generatePromptMessages(
           role: 'assistant',
           content: {
             type: 'text',
-            text: `Use pce.memory.activate to recall relevant knowledge.
+            text: `Use pce_memory_activate to recall relevant knowledge.
 
 \`\`\`json
 {
@@ -2106,7 +2106,7 @@ function generatePromptMessages(
           role: 'assistant',
           content: {
             type: 'text',
-            text: `Use pce.memory.upsert to record the design decision.
+            text: `Use pce_memory_upsert to record the design decision.
 
 \`\`\`json
 {
@@ -2151,7 +2151,7 @@ function generatePromptMessages(
       const operationGuides: Record<string, string> = {
         push: `## Push: Export Local Knowledge
 
-Use pce.memory.sync.push to export knowledge from the local DB to .pce-shared/.
+Use pce_memory_sync_push to export knowledge from the local DB to .pce-shared/.
 
 \`\`\`json
 {
@@ -2172,7 +2172,7 @@ Use pce.memory.sync.push to export knowledge from the local DB to .pce-shared/.
 
         pull: `## Pull: Import Shared Knowledge
 
-Use pce.memory.sync.pull to import knowledge from .pce-shared/.
+Use pce_memory_sync_pull to import knowledge from .pce-shared/.
 
 \`\`\`json
 {
@@ -2194,7 +2194,7 @@ Use pce.memory.sync.pull to import knowledge from .pce-shared/.
 
         status: `## Status: Check Sync State
 
-Use pce.memory.sync.status to check the state of the sync directory.
+Use pce_memory_sync_status to check the state of the sync directory.
 
 \`\`\`json
 {}
@@ -2268,7 +2268,7 @@ export PCE_SYNC_ENABLED=true
           role: 'assistant',
           content: {
             type: 'text',
-            text: `Use pce.memory.sync.push to export knowledge to .pce-shared/ directory.
+            text: `Use pce_memory_sync_push to export knowledge to .pce-shared/ directory.
 
 \`\`\`json
 {
@@ -2325,7 +2325,7 @@ git push
           role: 'assistant',
           content: {
             type: 'text',
-            text: `Use pce.memory.sync.pull to import knowledge from .pce-shared/ directory.
+            text: `Use pce_memory_sync_pull to import knowledge from .pce-shared/ directory.
 
 ## Step 1: Preview Changes (Recommended)
 
@@ -2386,7 +2386,7 @@ git push
           role: 'assistant',
           content: {
             type: 'text',
-            text: `Use pce.memory.activate to search for past similar issues and solutions.
+            text: `Use pce_memory_activate to search for past similar issues and solutions.
 
 \`\`\`json
 {
@@ -2503,7 +2503,7 @@ export async function handleGetPrompt(args: Record<string, unknown>): Promise<{
 
 export const TOOL_DEFINITIONS = [
   {
-    name: 'pce.memory.policy.apply',
+    name: 'pce_memory_policy_apply',
     description:
       'Initialize memory system with policy configuration. Call once at session start before using other tools. Configures boundary rules, redaction patterns, and rate limits.',
     inputSchema: {
@@ -2528,7 +2528,7 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
-    name: 'pce.memory.observe',
+    name: 'pce_memory_observe',
     description:
       'Record a temporary observation with auto-expiry (default 30 days). Use for chat logs, tool outputs, file reads, API responses. Set extract.mode="single_claim_v0" to promote to permanent claim. Auto-detects and redacts PII/secrets.',
     inputSchema: {
@@ -2599,7 +2599,7 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
-    name: 'pce.memory.upsert',
+    name: 'pce_memory_upsert',
     description:
       'Register a permanent knowledge claim (never auto-deleted). Use for verified decisions, resolved errors, architectural patterns. Requires provenance.at timestamp. Prefer over observe for long-term, validated knowledge.',
     inputSchema: {
@@ -2711,7 +2711,7 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
-    name: 'pce.memory.activate',
+    name: 'pce_memory_activate',
     description:
       'Retrieve relevant knowledge for current task via hybrid search. Call before starting work to recall past decisions, patterns, and solutions. Returns ranked claims filtered by scope and boundary.',
     inputSchema: {
@@ -2780,7 +2780,7 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
-    name: 'pce.memory.boundary.validate',
+    name: 'pce_memory_boundary_validate',
     description:
       'Validate and redact sensitive content before outputting to user. Checks for PII, secrets, and boundary policy violations. Returns sanitized payload safe for external use.',
     inputSchema: {
@@ -2819,7 +2819,7 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
-    name: 'pce.memory.feedback',
+    name: 'pce_memory_feedback',
     description:
       'Report knowledge quality after using activated claims. Send helpful when knowledge solved the problem, harmful if it caused errors, outdated if info was stale, duplicate if redundant.',
     inputSchema: {
@@ -2854,7 +2854,7 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
-    name: 'pce.memory.state',
+    name: 'pce_memory_state',
     description: 'Get current state machine status (Uninitialized/PolicyApplied/HasClaims/Ready)',
     inputSchema: {
       type: 'object',
@@ -2886,7 +2886,7 @@ export const TOOL_DEFINITIONS = [
   },
   // ========== Graph Memory Tools ==========
   {
-    name: 'pce.memory.upsert.entity',
+    name: 'pce_memory_upsert_entity',
     description: 'Register an entity in graph memory (Actor/Artifact/Event/Concept)',
     inputSchema: {
       type: 'object',
@@ -2930,7 +2930,7 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
-    name: 'pce.memory.upsert.relation',
+    name: 'pce_memory_upsert_relation',
     description: 'Register a relation between entities in graph memory',
     inputSchema: {
       type: 'object',
@@ -2977,7 +2977,7 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
-    name: 'pce.memory.query.entity',
+    name: 'pce_memory_query_entity',
     description:
       'Query entities from graph memory. At least one filter is required: id, type, canonical_key, or claim_id. Use limit to control result count.',
     inputSchema: {
@@ -3032,7 +3032,7 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
-    name: 'pce.memory.query.relation',
+    name: 'pce_memory_query_relation',
     description:
       'Query relations from graph memory. At least one filter is required: id, src_id, dst_id, type, or evidence_claim_id. Use limit to control result count.',
     inputSchema: {
@@ -3086,7 +3086,7 @@ export const TOOL_DEFINITIONS = [
   },
   // ========== Sync Tools (Issue #18) ==========
   {
-    name: 'pce.memory.sync.push',
+    name: 'pce_memory_sync_push',
     description:
       'Export local claims/entities/relations to .pce-shared/ directory for Git-based CRDT sync',
     inputSchema: {
@@ -3156,7 +3156,7 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
-    name: 'pce.memory.sync.pull',
+    name: 'pce_memory_sync_pull',
     description:
       'Import claims/entities/relations from .pce-shared/ directory with CRDT merge strategy',
     inputSchema: {
@@ -3266,7 +3266,7 @@ export const TOOL_DEFINITIONS = [
   },
   // Phase 2: sync.status
   {
-    name: 'pce.memory.sync.status',
+    name: 'pce_memory_sync_status',
     description: 'Get sync directory status including manifest, file counts, and validation state',
     inputSchema: {
       type: 'object',

--- a/apps/pce-memory/test/activate-boundary-filter.test.ts
+++ b/apps/pce-memory/test/activate-boundary-filter.test.ts
@@ -19,10 +19,10 @@ beforeEach(async () => {
 
 describe('activate boundary filter', () => {
   it('allowに基づきboundary_classでフィルタされる', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
     const internalText = 'internal claim';
-    const internal = await dispatchTool('pce.memory.upsert', {
+    const internal = await dispatchTool('pce_memory_upsert', {
       text: internalText,
       kind: 'fact',
       scope: 'session',
@@ -30,7 +30,7 @@ describe('activate boundary filter', () => {
       content_hash: `sha256:${computeContentHash(internalText)}`,
     });
     const piiText = 'pii claim';
-    const pii = await dispatchTool('pce.memory.upsert', {
+    const pii = await dispatchTool('pce_memory_upsert', {
       text: piiText,
       kind: 'fact',
       scope: 'session',
@@ -38,7 +38,7 @@ describe('activate boundary filter', () => {
       content_hash: `sha256:${computeContentHash(piiText)}`,
     });
     const secretText = 'secret claim';
-    const secret = await dispatchTool('pce.memory.upsert', {
+    const secret = await dispatchTool('pce_memory_upsert', {
       text: secretText,
       kind: 'fact',
       scope: 'session',
@@ -50,7 +50,7 @@ describe('activate boundary filter', () => {
     const piiId = pii.structuredContent?.id as string;
     const secretId = secret.structuredContent?.id as string;
 
-    const ac1 = await dispatchTool('pce.memory.activate', {
+    const ac1 = await dispatchTool('pce_memory_activate', {
       scope: ['session'],
       allow: ['answer:task'],
       include_meta: false,
@@ -60,7 +60,7 @@ describe('activate boundary filter', () => {
     expect(claims1).not.toContain(piiId);
     expect(claims1).not.toContain(secretId);
 
-    const ac2 = await dispatchTool('pce.memory.activate', {
+    const ac2 = await dispatchTool('pce_memory_activate', {
       scope: ['session'],
       allow: ['tool:contact-lookup'],
       include_meta: false,

--- a/apps/pce-memory/test/observe.test.ts
+++ b/apps/pce-memory/test/observe.test.ts
@@ -17,16 +17,16 @@ beforeEach(async () => {
   await resetRates();
 });
 
-describe('pce.memory.observe', () => {
+describe('pce_memory_observe', () => {
   it('TOOL_DEFINITIONSに含まれる', () => {
     const names = TOOL_DEFINITIONS.map((t) => t.name);
-    expect(names).toContain('pce.memory.observe');
+    expect(names).toContain('pce_memory_observe');
   });
 
   it('extract.mode=noop: observation_idのみ返す（claim_idsは空）', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
-    const result = await dispatchTool('pce.memory.observe', {
+    const result = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: 'hello observation',
       extract: { mode: 'noop' },
@@ -49,9 +49,9 @@ describe('pce.memory.observe', () => {
   });
 
   it('extract.mode=single_claim_v0: claim_idsが返り、activate(include_meta)でEvidenceが返る', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
-    const obs = await dispatchTool('pce.memory.observe', {
+    const obs = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: 'my observation content',
       extract: { mode: 'single_claim_v0' },
@@ -63,7 +63,7 @@ describe('pce.memory.observe', () => {
     expect(obsData.claim_ids).toHaveLength(1);
     const claimId = (obsData.claim_ids as string[])[0]!;
 
-    const ac = await dispatchTool('pce.memory.activate', {
+    const ac = await dispatchTool('pce_memory_activate', {
       scope: ['session'],
       allow: ['answer:task'],
       include_meta: true,
@@ -82,10 +82,10 @@ describe('pce.memory.observe', () => {
   });
 
   it('secret検知時: contentは保存せずextractもスキップする', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
     const secretText = `sk-${'A'.repeat(30)}`;
-    const result = await dispatchTool('pce.memory.observe', {
+    const result = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: secretText,
       extract: { mode: 'single_claim_v0' },
@@ -109,9 +109,9 @@ describe('pce.memory.observe', () => {
   });
 
   it('GC(scrub): 期限切れ後にcontentがNULL化される', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
-    const result = await dispatchTool('pce.memory.observe', {
+    const result = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: 'will be scrubbed',
       ttl_days: 1,
@@ -139,9 +139,9 @@ describe('pce.memory.observe', () => {
   // Issue #30 Review: Edge case tests追加
 
   it('tags validation: 不正な文字を含むタグはエラーになる', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
-    const result = await dispatchTool('pce.memory.observe', {
+    const result = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: 'test content',
       tags: ['valid-tag', 'invalid<script>tag'],
@@ -154,10 +154,10 @@ describe('pce.memory.observe', () => {
   });
 
   it('tags validation: 長すぎるタグはエラーになる', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
     const longTag = 'a'.repeat(300); // 256文字を超える
-    const result = await dispatchTool('pce.memory.observe', {
+    const result = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: 'test content',
       tags: [longTag],
@@ -170,10 +170,10 @@ describe('pce.memory.observe', () => {
   });
 
   it('secret検知時: content_digestがREDACTED_SECRETになる', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
     const secretText = `sk-${'A'.repeat(30)}`;
-    const result = await dispatchTool('pce.memory.observe', {
+    const result = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: secretText,
       extract: { mode: 'noop' },
@@ -193,9 +193,9 @@ describe('pce.memory.observe', () => {
   });
 
   it('GC(scrub): 期限切れ後にactor, source_id, tagsもNULL化される', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
-    const result = await dispatchTool('pce.memory.observe', {
+    const result = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: 'will be scrubbed',
       actor: 'test-user@example.com',
@@ -233,10 +233,10 @@ describe('pce.memory.observe', () => {
   });
 
   it('tags validation: 有効なタグパターンは許可される', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
     // 許可される文字: [\w\-:.@/]
-    const result = await dispatchTool('pce.memory.observe', {
+    const result = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: 'test content',
       tags: ['valid-tag', 'user:name', 'path/to/resource', 'email@domain.com', 'under_score'],
@@ -251,7 +251,7 @@ describe('pce.memory.observe', () => {
 
   it('STATE_ERROR: Uninitializedでobserveするとエラー', async () => {
     // policy.applyを呼ばずにobserve
-    const result = await dispatchTool('pce.memory.observe', {
+    const result = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: 'test',
       extract: { mode: 'noop' },
@@ -262,9 +262,9 @@ describe('pce.memory.observe', () => {
   });
 
   it('VALIDATION_ERROR: source_type未指定', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
-    const result = await dispatchTool('pce.memory.observe', {
+    const result = await dispatchTool('pce_memory_observe', {
       content: 'test',
       extract: { mode: 'noop' },
     });
@@ -274,9 +274,9 @@ describe('pce.memory.observe', () => {
   });
 
   it('VALIDATION_ERROR: content未指定', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
-    const result = await dispatchTool('pce.memory.observe', {
+    const result = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       extract: { mode: 'noop' },
     });
@@ -286,9 +286,9 @@ describe('pce.memory.observe', () => {
   });
 
   it('VALIDATION_ERROR: boundary_class不正値', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
-    const result = await dispatchTool('pce.memory.observe', {
+    const result = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: 'test',
       boundary_class: 'invalid_class',
@@ -301,11 +301,11 @@ describe('pce.memory.observe', () => {
   });
 
   it('VALIDATION_ERROR: contentサイズ上限超過', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
     // デフォルト上限は64KB
     const largeContent = 'x'.repeat(100_000);
-    const result = await dispatchTool('pce.memory.observe', {
+    const result = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: largeContent,
       extract: { mode: 'noop' },
@@ -319,9 +319,9 @@ describe('pce.memory.observe', () => {
   // === 追加テスト: PII/GC ===
 
   it('PII検知: メールアドレスがリダクションされDBに保存', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
-    const result = await dispatchTool('pce.memory.observe', {
+    const result = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: '連絡先: test@example.com です',
       extract: { mode: 'noop' },
@@ -343,9 +343,9 @@ describe('pce.memory.observe', () => {
   });
 
   it('PII検知: 電話番号がリダクションされDBに保存', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
-    const result = await dispatchTool('pce.memory.observe', {
+    const result = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: '電話: 090-1234-5678 まで',
       extract: { mode: 'noop' },
@@ -365,9 +365,9 @@ describe('pce.memory.observe', () => {
   });
 
   it('GC(delete): 期限切れ後に行が削除される', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
-    const result = await dispatchTool('pce.memory.observe', {
+    const result = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: 'will be deleted',
       ttl_days: 1,
@@ -393,9 +393,9 @@ describe('pce.memory.observe', () => {
   // === 追加テスト: エッジケース ===
 
   it('空content: 空文字列でもobserve可能', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
-    const result = await dispatchTool('pce.memory.observe', {
+    const result = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: '',
       extract: { mode: 'noop' },
@@ -407,10 +407,10 @@ describe('pce.memory.observe', () => {
   });
 
   it('日本語content: マルチバイト文字が正しく保存される', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
     const japaneseContent = 'これは日本語のテストです。絵文字も含む🎉';
-    const result = await dispatchTool('pce.memory.observe', {
+    const result = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: japaneseContent,
       extract: { mode: 'noop' },
@@ -428,17 +428,17 @@ describe('pce.memory.observe', () => {
   });
 
   it('重複observe: 同一contentでも別のobservation_idが生成される', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
     const content = 'duplicate content test';
 
-    const result1 = await dispatchTool('pce.memory.observe', {
+    const result1 = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content,
       extract: { mode: 'noop' },
     });
 
-    const result2 = await dispatchTool('pce.memory.observe', {
+    const result2 = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content,
       extract: { mode: 'noop' },
@@ -450,12 +450,12 @@ describe('pce.memory.observe', () => {
   });
 
   it('source_type全種: 各source_typeでobserve可能', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
     const sourceTypes = ['chat', 'tool', 'file', 'http', 'system'] as const;
 
     for (const sourceType of sourceTypes) {
-      const result = await dispatchTool('pce.memory.observe', {
+      const result = await dispatchTool('pce_memory_observe', {
         source_type: sourceType,
         content: `content for ${sourceType}`,
         extract: { mode: 'noop' },
@@ -467,9 +467,9 @@ describe('pce.memory.observe', () => {
   });
 
   it('boundary_class昇格: 明示的publicでもPII検知でpiiに昇格', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
-    const result = await dispatchTool('pce.memory.observe', {
+    const result = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: 'public info with email: secret@example.com',
       boundary_class: 'public',
@@ -485,10 +485,10 @@ describe('pce.memory.observe', () => {
   // === Claim昇格（extract）詳細テスト ===
 
   it('extract: claim.textがcontentと一致する', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
     const testContent = 'テスト用のコンテンツ文字列';
-    const obs = await dispatchTool('pce.memory.observe', {
+    const obs = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: testContent,
       extract: { mode: 'single_claim_v0' },
@@ -504,9 +504,9 @@ describe('pce.memory.observe', () => {
   });
 
   it('extract: claim属性が正しく設定される (kind=fact, scope=session)', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
-    const obs = await dispatchTool('pce.memory.observe', {
+    const obs = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: '設計決定: APIはREST形式',
       extract: { mode: 'single_claim_v0' },
@@ -531,9 +531,9 @@ describe('pce.memory.observe', () => {
   });
 
   it('extract: boundary_classがeffectiveBoundaryClassに従う', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
-    const obs = await dispatchTool('pce.memory.observe', {
+    const obs = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: '公開可能な情報です',
       boundary_class: 'public',
@@ -552,7 +552,7 @@ describe('pce.memory.observe', () => {
   });
 
   it('extract: provenanceがobserveからclaimに引き継がれる', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
     const testProvenance = {
       at: '2024-12-16T12:00:00Z',
@@ -560,7 +560,7 @@ describe('pce.memory.observe', () => {
       note: 'ADR-001で決定',
     };
 
-    const obs = await dispatchTool('pce.memory.observe', {
+    const obs = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: 'provenance引き継ぎテスト',
       provenance: testProvenance,
@@ -584,10 +584,10 @@ describe('pce.memory.observe', () => {
   });
 
   it('extract: PII検知時はリダクション済みtextでclaim生成', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
     const contentWithPII = '連絡先: pii-test@example.com です';
-    const obs = await dispatchTool('pce.memory.observe', {
+    const obs = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: contentWithPII,
       extract: { mode: 'single_claim_v0' },
@@ -613,12 +613,12 @@ describe('pce.memory.observe', () => {
   });
 
   it('extract: 同一contentは既存claimを再利用（重複防止）', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
     const sharedContent = '重複テスト用の同一コンテンツ';
 
     // 1回目のobserve
-    const obs1 = await dispatchTool('pce.memory.observe', {
+    const obs1 = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: sharedContent,
       extract: { mode: 'single_claim_v0' },
@@ -626,7 +626,7 @@ describe('pce.memory.observe', () => {
     const claimId1 = (obs1.structuredContent!.claim_ids as string[])[0]!;
 
     // 2回目のobserve（同一content）
-    const obs2 = await dispatchTool('pce.memory.observe', {
+    const obs2 = await dispatchTool('pce_memory_observe', {
       source_type: 'tool',
       source_id: 'tool:test',
       content: sharedContent,
@@ -642,10 +642,10 @@ describe('pce.memory.observe', () => {
   });
 
   it('extract: Evidence詳細検証（source_type, source_id, snippet）', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
     const testContent = 'Evidence詳細検証テスト';
-    const obs = await dispatchTool('pce.memory.observe', {
+    const obs = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: testContent,
       extract: { mode: 'single_claim_v0' },
@@ -674,9 +674,9 @@ describe('pce.memory.observe', () => {
   });
 
   it('extract: provenanceなしでもclaim生成可能', async () => {
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
-    const obs = await dispatchTool('pce.memory.observe', {
+    const obs = await dispatchTool('pce_memory_observe', {
       source_type: 'system',
       content: 'provenance省略テスト',
       extract: { mode: 'single_claim_v0' },

--- a/apps/pce-memory/test/output-schema.test.ts
+++ b/apps/pce-memory/test/output-schema.test.ts
@@ -50,8 +50,8 @@ describe('Output Schema - 基本テスト', () => {
 });
 
 describe('Output Schema - 後方互換性テスト', () => {
-  it('pce.memory.policy.apply: contentとstructuredContentの両方が返される', async () => {
-    const result = await dispatchTool('pce.memory.policy.apply', {});
+  it('pce_memory_policy_apply: contentとstructuredContentの両方が返される', async () => {
+    const result = await dispatchTool('pce_memory_policy_apply', {});
 
     // 後方互換性: content配列は常に存在
     expect(result.content).toBeDefined();
@@ -67,8 +67,8 @@ describe('Output Schema - 後方互換性テスト', () => {
     expect(result.structuredContent).toEqual(contentData);
   });
 
-  it('pce.memory.state: contentとstructuredContentの両方が返される', async () => {
-    const result = await dispatchTool('pce.memory.state', {});
+  it('pce_memory_state: contentとstructuredContentの両方が返される', async () => {
+    const result = await dispatchTool('pce_memory_state', {});
 
     expect(result.content).toBeDefined();
     expect(result.structuredContent).toBeDefined();
@@ -79,8 +79,8 @@ describe('Output Schema - 後方互換性テスト', () => {
 });
 
 describe('Output Schema - ハンドラ出力検証', () => {
-  it('pce.memory.policy.apply: 出力がスキーマに準拠', async () => {
-    const result = await dispatchTool('pce.memory.policy.apply', {});
+  it('pce_memory_policy_apply: 出力がスキーマに準拠', async () => {
+    const result = await dispatchTool('pce_memory_policy_apply', {});
     const data = result.structuredContent!;
 
     // 必須フィールドの存在確認
@@ -90,12 +90,12 @@ describe('Output Schema - ハンドラ出力検証', () => {
     expect(data.trace_id).toBeDefined();
   });
 
-  it('pce.memory.upsert: 出力がスキーマに準拠', async () => {
+  it('pce_memory_upsert: 出力がスキーマに準拠', async () => {
     // 事前にpolicy.applyを実行
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
     const text = 'テスト知識';
-    const result = await dispatchTool('pce.memory.upsert', {
+    const result = await dispatchTool('pce_memory_upsert', {
       text,
       kind: 'fact',
       scope: 'session',
@@ -112,11 +112,11 @@ describe('Output Schema - ハンドラ出力検証', () => {
     expect(data.trace_id).toBeDefined();
   });
 
-  it('pce.memory.activate: 出力がスキーマに準拠', async () => {
+  it('pce_memory_activate: 出力がスキーマに準拠', async () => {
     // 事前にpolicy.applyとupsertを実行
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
     const activateText = 'テスト知識activate';
-    await dispatchTool('pce.memory.upsert', {
+    await dispatchTool('pce_memory_upsert', {
       text: activateText,
       kind: 'fact',
       scope: 'session',
@@ -124,7 +124,7 @@ describe('Output Schema - ハンドラ出力検証', () => {
       content_hash: `sha256:${computeContentHash(activateText)}`,
     });
 
-    const result = await dispatchTool('pce.memory.activate', {
+    const result = await dispatchTool('pce_memory_activate', {
       scope: ['session'],
       allow: ['answer:task'],
     });
@@ -140,8 +140,8 @@ describe('Output Schema - ハンドラ出力検証', () => {
     expect(data.trace_id).toBeDefined();
   });
 
-  it('pce.memory.boundary.validate: 出力がスキーマに準拠', async () => {
-    const result = await dispatchTool('pce.memory.boundary.validate', {
+  it('pce_memory_boundary_validate: 出力がスキーマに準拠', async () => {
+    const result = await dispatchTool('pce_memory_boundary_validate', {
       payload: 'テストペイロード',
     });
     const data = result.structuredContent!;
@@ -153,11 +153,11 @@ describe('Output Schema - ハンドラ出力検証', () => {
     expect(data.trace_id).toBeDefined();
   });
 
-  it('pce.memory.feedback: 出力がスキーマに準拠', async () => {
+  it('pce_memory_feedback: 出力がスキーマに準拠', async () => {
     // 事前にpolicy.applyとupsertを実行してclaimを作成
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
     const feedbackText = 'テスト知識feedback';
-    const upsertResult = await dispatchTool('pce.memory.upsert', {
+    const upsertResult = await dispatchTool('pce_memory_upsert', {
       text: feedbackText,
       kind: 'fact',
       scope: 'session',
@@ -167,12 +167,12 @@ describe('Output Schema - ハンドラ出力検証', () => {
     const claimId = upsertResult.structuredContent!.id as string;
 
     // activateしてReady状態にする
-    await dispatchTool('pce.memory.activate', {
+    await dispatchTool('pce_memory_activate', {
       scope: ['session'],
       allow: ['answer:task'],
     });
 
-    const result = await dispatchTool('pce.memory.feedback', {
+    const result = await dispatchTool('pce_memory_feedback', {
       claim_id: claimId,
       signal: 'helpful',
     });
@@ -185,8 +185,8 @@ describe('Output Schema - ハンドラ出力検証', () => {
     expect(data.trace_id).toBeDefined();
   });
 
-  it('pce.memory.state: 出力がスキーマに準拠', async () => {
-    const result = await dispatchTool('pce.memory.state', {});
+  it('pce_memory_state: 出力がスキーマに準拠', async () => {
+    const result = await dispatchTool('pce_memory_state', {});
     const data = result.structuredContent!;
 
     expect(['Uninitialized', 'PolicyApplied', 'HasClaims', 'Ready']).toContain(data.state);
@@ -195,11 +195,11 @@ describe('Output Schema - ハンドラ出力検証', () => {
     expect(data.trace_id).toBeDefined();
   });
 
-  it('pce.memory.upsert.entity: 出力がスキーマに準拠', async () => {
+  it('pce_memory_upsert_entity: 出力がスキーマに準拠', async () => {
     // 事前にpolicy.applyを実行
-    await dispatchTool('pce.memory.policy.apply', {});
+    await dispatchTool('pce_memory_policy_apply', {});
 
-    const result = await dispatchTool('pce.memory.upsert.entity', {
+    const result = await dispatchTool('pce_memory_upsert_entity', {
       id: 'ent_test_001',
       type: 'Concept',
       name: 'テストエンティティ',
@@ -215,21 +215,21 @@ describe('Output Schema - ハンドラ出力検証', () => {
     expect(data.trace_id).toBeDefined();
   });
 
-  it('pce.memory.upsert.relation: 出力がスキーマに準拠', async () => {
+  it('pce_memory_upsert_relation: 出力がスキーマに準拠', async () => {
     // 事前にpolicy.applyとエンティティを作成
-    await dispatchTool('pce.memory.policy.apply', {});
-    await dispatchTool('pce.memory.upsert.entity', {
+    await dispatchTool('pce_memory_policy_apply', {});
+    await dispatchTool('pce_memory_upsert_entity', {
       id: 'ent_src',
       type: 'Concept',
       name: 'ソースエンティティ',
     });
-    await dispatchTool('pce.memory.upsert.entity', {
+    await dispatchTool('pce_memory_upsert_entity', {
       id: 'ent_dst',
       type: 'Concept',
       name: 'ターゲットエンティティ',
     });
 
-    const result = await dispatchTool('pce.memory.upsert.relation', {
+    const result = await dispatchTool('pce_memory_upsert_relation', {
       id: 'rel_test_001',
       src_id: 'ent_src',
       dst_id: 'ent_dst',
@@ -247,16 +247,16 @@ describe('Output Schema - ハンドラ出力検証', () => {
     expect(data.trace_id).toBeDefined();
   });
 
-  it('pce.memory.query.entity: 出力がスキーマに準拠', async () => {
+  it('pce_memory_query_entity: 出力がスキーマに準拠', async () => {
     // 事前にpolicy.applyとエンティティを作成
-    await dispatchTool('pce.memory.policy.apply', {});
-    await dispatchTool('pce.memory.upsert.entity', {
+    await dispatchTool('pce_memory_policy_apply', {});
+    await dispatchTool('pce_memory_upsert_entity', {
       id: 'ent_query_test',
       type: 'Concept',
       name: 'クエリテストエンティティ',
     });
 
-    const result = await dispatchTool('pce.memory.query.entity', {
+    const result = await dispatchTool('pce_memory_query_entity', {
       type: 'Concept',
     });
     const data = result.structuredContent!;
@@ -269,27 +269,27 @@ describe('Output Schema - ハンドラ出力検証', () => {
     expect(data.trace_id).toBeDefined();
   });
 
-  it('pce.memory.query.relation: 出力がスキーマに準拠', async () => {
+  it('pce_memory_query_relation: 出力がスキーマに準拠', async () => {
     // 事前にpolicy.applyとリレーションを作成
-    await dispatchTool('pce.memory.policy.apply', {});
-    await dispatchTool('pce.memory.upsert.entity', {
+    await dispatchTool('pce_memory_policy_apply', {});
+    await dispatchTool('pce_memory_upsert_entity', {
       id: 'ent_rel_src',
       type: 'Actor',
       name: 'リレーションソース',
     });
-    await dispatchTool('pce.memory.upsert.entity', {
+    await dispatchTool('pce_memory_upsert_entity', {
       id: 'ent_rel_dst',
       type: 'Artifact',
       name: 'リレーションターゲット',
     });
-    await dispatchTool('pce.memory.upsert.relation', {
+    await dispatchTool('pce_memory_upsert_relation', {
       id: 'rel_query_test',
       src_id: 'ent_rel_src',
       dst_id: 'ent_rel_dst',
       type: 'CREATED',
     });
 
-    const result = await dispatchTool('pce.memory.query.relation', {
+    const result = await dispatchTool('pce_memory_query_relation', {
       type: 'CREATED',
     });
     const data = result.structuredContent!;
@@ -306,7 +306,7 @@ describe('Output Schema - ハンドラ出力検証', () => {
 describe('Property: structuredContent整合性', () => {
   it('Property: contentとstructuredContentは常に同一データを表現する', async () => {
     // policy.applyを実行
-    const result = await dispatchTool('pce.memory.policy.apply', {});
+    const result = await dispatchTool('pce_memory_policy_apply', {});
 
     // contentをパースしてstructuredContentと比較
     const parsedContent = JSON.parse(result.content[0].text);
@@ -319,7 +319,7 @@ describe('Property: structuredContent整合性', () => {
 describe('Output Schema - エラー時の出力', () => {
   it('バリデーションエラー時もcontent配列が存在しisErrorがtrue', async () => {
     // policy.applyなしでupsertを実行（STATE_ERROR）
-    const result = await dispatchTool('pce.memory.upsert', {
+    const result = await dispatchTool('pce_memory_upsert', {
       text: 'テスト',
       kind: 'fact',
       scope: 'session',

--- a/apps/pce-memory/test/prompts.test.ts
+++ b/apps/pce-memory/test/prompts.test.ts
@@ -123,7 +123,7 @@ describe('MCP Prompts (Issue #16)', () => {
       });
       const allText = result.messages.map((m) => m.content.text).join(' ');
       expect(allText).toContain('Push');
-      expect(allText).toContain('sync.push');
+      expect(allText).toContain('pce_memory_sync_push');
     });
 
     it('returns pull guide with operation=pull', async () => {
@@ -142,7 +142,7 @@ describe('MCP Prompts (Issue #16)', () => {
       const result = await handleGetPrompt({ name: 'sync_push' });
       expect(result.messages.length).toBeGreaterThan(0);
       const allText = result.messages.map((m) => m.content.text).join(' ');
-      expect(allText).toContain('pce.memory.sync.push');
+      expect(allText).toContain('pce_memory_sync_push');
       expect(allText).toContain('scope_filter');
       expect(allText).toContain('boundary_filter');
     });
@@ -164,7 +164,7 @@ describe('MCP Prompts (Issue #16)', () => {
       const result = await handleGetPrompt({ name: 'sync_pull' });
       expect(result.messages.length).toBeGreaterThan(0);
       const allText = result.messages.map((m) => m.content.text).join(' ');
-      expect(allText).toContain('pce.memory.sync.pull');
+      expect(allText).toContain('pce_memory_sync_pull');
       expect(allText).toContain('dry_run');
       expect(allText).toContain('CRDT');
     });

--- a/apps/pce-memory/test/schema-migration-observations.test.ts
+++ b/apps/pce-memory/test/schema-migration-observations.test.ts
@@ -59,8 +59,8 @@ describe('Schema migration: legacy observations', () => {
     expect(rows[0]?.expires_at).toBeDefined();
 
     // observeが新スキーマで動作する
-    await dispatchTool('pce.memory.policy.apply', {});
-    const obs = await dispatchTool('pce.memory.observe', {
+    await dispatchTool('pce_memory_policy_apply', {});
+    const obs = await dispatchTool('pce_memory_observe', {
       source_type: 'chat',
       content: 'post-migration observation',
       extract: { mode: 'noop' },

--- a/apps/pce-memory/tests/eval/goldens/observe.yaml
+++ b/apps/pce-memory/tests/eval/goldens/observe.yaml
@@ -1,7 +1,7 @@
 schemaVersion: "1.0.0"
 version: "v2024-12-16"
 name: pce-memory-observe-golden
-description: pce.memory.observe 機能評価用goldenset
+description: pce_memory_observe 機能評価用goldenset
 
 defaultParams:
   timeoutMs: 30000

--- a/docs/activation-ranking.md
+++ b/docs/activation-ranking.md
@@ -1,6 +1,6 @@
 # Activation & Ranking Spec (r, S, g) — pce‑memory v0.1
 
-> **目的**：MCP ツール `pce.memory.activate` / `pce.memory.search` が返す候補の **選別（Activation: r）**、**スコアリング（融合: S）**、**再ランク（g）** を定義する。DuckDB スキーマ（`schema.md`）/ 検索拡張（`search_extensions_duckdb.md`）/ 境界（`boundary-policy.md`）と整合する。
+> **目的**：MCP ツール `pce_memory_activate` / `pce_memory_search` が返す候補の **選別（Activation: r）**、**スコアリング（融合: S）**、**再ランク（g）** を定義する。DuckDB スキーマ（`schema.md`）/ 検索拡張（`search_extensions_duckdb.md`）/ 境界（`boundary-policy.md`）と整合する。
 
 - **前提**：`r(q, C^L, B, policy, critic)` は **AC（Active Context）** を構成する関数。境界（Boundary）による前置フィルタを必須とし、FTS/VSS の有無に応じて内部戦略を切替える。
 - **出力**：`active_contexts(id, scope, expires_at, policy_version, provenance)` と `active_context_items(ac_id, claim_id, rank, score)`、および UI/エージェント用の **説明用メタ**（s_text, s_vec, S, g, reason）を返す。
@@ -196,7 +196,7 @@ LEFT JOIN vec ON vec.id=ids.id;
 
 ---
 
-## 6. MCP 連携（`pce.memory.activate` / `pce.memory.search`）
+## 6. MCP 連携（`pce_memory_activate` / `pce_memory_search`）
 
 - `activate`：上記フローで AC を生成し、`active_contexts`/`active_context_items` を保存。レスポンスには `rank/score_final` に加え、`s_text/s_vec/S/g` のブレークダウンを **任意で**返す。
 - `search`：AC を作らず、`score_final` で上位 k を返す。`policy_version` と `provenance`、`request_id/trace_id` を必ず同梱。

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -23,7 +23,7 @@
 
 ## いつ activate するか
 
-以下の状況で `pce.memory.activate` を呼び出してください：
+以下の状況で `pce_memory_activate` を呼び出してください：
 
 - **新しいタスクを開始するとき** - 関連する過去の決定を確認
 - **設計判断が必要なとき** - 既存のアーキテクチャ決定を参照
@@ -44,7 +44,7 @@
 
 ## いつ upsert するか
 
-以下の情報を `pce.memory.upsert` で記録してください：
+以下の情報を `pce_memory_upsert` で記録してください：
 
 ### kind: fact（事実）
 
@@ -109,7 +109,7 @@
 
 ## feedback を送るタイミング
 
-activateで取得した知識が役立ったかを `pce.memory.feedback` で報告してください：
+activateで取得した知識が役立ったかを `pce_memory_feedback` で報告してください：
 
 | signal      | いつ送るか                                |
 | ----------- | ----------------------------------------- |
@@ -201,7 +201,7 @@ Agent:
 ### 1. タグをEntityとして登録
 
 ```json
-// pce.memory.upsert.entity
+// pce_memory_upsert_entity
 {
   "id": "tag_typescript",
   "type": "Concept",
@@ -212,7 +212,7 @@ Agent:
 ### 2. ClaimとタグをRelationで紐付け
 
 ```json
-// pce.memory.upsert.relation
+// pce_memory_upsert_relation
 {
   "id": "rel_clm_tag_001",
   "src_id": "clm_abc123",
@@ -224,7 +224,7 @@ Agent:
 ### 3. upsert時にentitiesとrelationsを同時登録
 
 ```json
-// pce.memory.upsert（一括登録）
+// pce_memory_upsert（一括登録）
 {
   "text": "TypeScriptのexactOptionalPropertyTypesに注意",
   "kind": "fact",

--- a/docs/boundary-policy.md
+++ b/docs/boundary-policy.md
@@ -23,18 +23,18 @@
 
 ### 1.1 Retrieval / Activation
 
-- `pce.memory.search` / `pce.memory.activate` は **前置フィルタ**で `scope/allow/boundary_class` を照合。
+- `pce_memory_search` / `pce_memory_activate` は **前置フィルタ**で `scope/allow/boundary_class` を照合。
 - AC 生成関数 `r(q, C^L, B, policy, critic)` は、許可範囲内の断片のみを候補にする。
 - 返却は **read-only**、出典（evidences）と `policy_version` を必須。
 
 ### 1.2 Generation 前後
 
-- 生成 **前**：`pce.memory.boundary.validate(payload, allow?, scope?)` を必ず呼ぶ。
+- 生成 **前**：`pce_memory_boundary_validate(payload, allow?, scope?)` を必ず呼ぶ。
 - 生成 **後**：必要に応じて再度 `validate`、許可外の語や PII/Secret を自動 Redact。
 
 ### 1.3 Write（Upsert / Distill / Rollback）
 
-- `pce.memory.upsert` は `boundary_class` 必須。`secret` は原則拒否（例外は人手レビュー）。
+- `pce_memory_upsert` は `boundary_class` 必須。`secret` は原則拒否（例外は人手レビュー）。
 - **Distill（蒸留）**：AC→LCP 昇格時は I(B) を再検証し、由来を必須添付。
 - **Rollback（沈降）**：越境/誤り検知時に LCP の安全側へ巻戻す（監査ログと連動）。
 
@@ -112,7 +112,7 @@ retrieval:
 - `retrieval.rerank.use_quality`：`g` に `quality` を乗算するかのフラグ（既定 false）。
 - `retrieval.rerank.recency_half_life_days`：再ランク `recency` の半減期（既定 30 日）。
 - `retrieval.rerank.recency.half_life_days_by_kind`：`kind` 別の半減期。`fact=120, task=14, preference=90, policy_hint=365` を初期値とする。
-- **実装**：`pce.memory.activate` / `pce.memory.search` は、これらのパラメータを読み込み `r/S/g` の計算に反映する（詳細は `activation-ranking.md`）。
+- **実装**：`pce_memory_activate` / `pce_memory_search` は、これらのパラメータを読み込み `r/S/g` の計算に反映する（詳細は `activation-ranking.md`）。
 
 ### 2.x 合成・優先順位（precedence）
 
@@ -232,7 +232,7 @@ redact_policies:
 
 ## 5. MCP ツールと境界
 
-- **validate**：`pce.memory.boundary.validate(payload, allow?, scope?)`
+- **validate**：`pce_memory_boundary_validate(payload, allow?, scope?)`
   - `allowed: boolean`, `redacted?: string`, `reason`, `policy_version`
 - **activate/search**：`scope/allow` を必須化。候補は境界内の断片のみ。
   - `retrieval.*` パラメータ（hybrid/rerank）は `activate`/`search` 内のスコアリングに適用される（`activation-ranking.md` 参照）。

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -14,7 +14,7 @@
 - **応答**: すべての成功レスポンスは **`policy_version`** と **`provenance`**（可能な範囲）を含める。
 - **Idempotency**: `upsert` は **content_hash** で冪等。`feedback` は `(claim_id, ts_bucket)` で冪等。
 - **Logging**: すべての呼び出しは append-only 監査ログに記録（時刻・呼出・境界判定・由来）。
-- **Scoring / Retrieval**: `pce.memory.activate` / `pce.memory.search` は **policy (`retrieval.*`)** を読み取り、ハイブリッド結合（`alpha/k_*`）と再ランク（`use_quality`/`recency`）を適用する。スコアは `activation-ranking.md` の定義に従い **[0,1] 正規化**され、`score` は最終スコア（`combined*g`）を表す。必要に応じて詳細内訳は `include_meta:true` で返す。
+- **Scoring / Retrieval**: `pce_memory_activate` / `pce_memory_search` は **policy (`retrieval.*`)** を読み取り、ハイブリッド結合（`alpha/k_*`）と再ランク（`use_quality`/`recency`）を適用する。スコアは `activation-ranking.md` の定義に従い **[0,1] 正規化**され、`score` は最終スコア（`combined*g`）を表す。必要に応じて詳細内訳は `include_meta:true` で返す。
 
 ---
 
@@ -86,7 +86,7 @@
 
 ## 2. Tools
 
-### 2.0 `pce.memory.observe`
+### 2.0 `pce_memory_observe`
 
 **目的**: 生データ（Observation）を**短期TTLで保持**し、必要に応じて Claim に昇格して Evidence を残す（Issue #30）。
 
@@ -178,7 +178,7 @@
     - `extract.mode=single_claim_v0` を指定されても `noop` にフォールバックし、`warnings` を返す
   - 期限後は Observation.content を削除/スクラブし、digest/メタデータのみ保持する運用を推奨（GCは起動時 + best-effortで実行）。
 
-### 2.1 `pce.memory.activate`
+### 2.1 `pce_memory_activate`
 
 **目的**: クエリとポリシーに基づき **アクティブコンテキスト（AC）** を構成（関数 `r(q, C^L, B, policy, critic)`）。
 
@@ -256,7 +256,7 @@
 
 ---
 
-### 2.2 `pce.memory.search`
+### 2.2 `pce_memory_search`
 
 **目的**: 既知の前提・規約・禁止事項を想起（AC の取得無し）。
 
@@ -301,7 +301,7 @@
 
 ---
 
-### 2.3 `pce.memory.upsert`
+### 2.3 `pce_memory_upsert`
 
 **目的**: 重要な断片（Observation/Claim/Graph）を登録。**由来（provenance）必須**。
 
@@ -387,7 +387,7 @@
 
 ---
 
-### 2.4 `pce.memory.feedback`
+### 2.4 `pce_memory_feedback`
 
 **目的**: 採用/棄却/陳腐化/重複のシグナルで Critic を更新。
 
@@ -422,7 +422,7 @@
 
 ---
 
-### 2.5 `pce.memory.boundary.validate`
+### 2.5 `pce_memory_boundary_validate`
 
 **目的**: 生成前に境界チェック／**Redact-before-Send**。
 
@@ -462,7 +462,7 @@
 
 ---
 
-### 2.6 `pce.memory.policy.apply`
+### 2.6 `pce_memory_policy_apply`
 
 **目的**: ポリシーの適用（不変量・用途タグ・redact ルール）。**GitOps 承認推奨**。
 

--- a/docs/mcp_quickstart.md
+++ b/docs/mcp_quickstart.md
@@ -99,7 +99,7 @@ boundary_classes:
 ### 2.2 Claude Code / Codex（例）
 
 - それぞれの MCP 設定で **stdio** サーバを登録（上記と同等のコマンド/引数/環境変数）
-- ツール一覧に `pce.memory.*` が見えたら OK。
+- ツール一覧に `pce_memory_*` が見えたら OK。
 
 ---
 
@@ -109,7 +109,7 @@ boundary_classes:
 
 ### 3.1 policy.apply（最初だけ）
 
-**ツール**：`pce.memory.policy.apply`  
+**ツール**：`pce_memory_policy_apply`  
 **Payload**：
 
 ```json
@@ -122,7 +122,7 @@ boundary_classes:
 
 ### 3.2 upsert（既知の前提を 2 件登録）
 
-**ツール**：`pce.memory.upsert`  
+**ツール**：`pce_memory_upsert`  
 **Payload 例**：
 
 ```json
@@ -138,7 +138,7 @@ boundary_classes:
 
 ### 3.3 activate（AC を構成し、前提をまとめて取得）
 
-**ツール**：`pce.memory.activate`  
+**ツール**：`pce_memory_activate`  
 **Payload**：
 
 ```json
@@ -149,7 +149,7 @@ boundary_classes:
 
 ### 3.4 boundary.validate（生成前チェック＆マスク）
 
-**ツール**：`pce.memory.boundary.validate`  
+**ツール**：`pce_memory_boundary_validate`  
 **Payload**：
 
 ```json
@@ -160,7 +160,7 @@ boundary_classes:
 
 ### 3.5 feedback（採用/棄却を学習）
 
-**ツール**：`pce.memory.feedback`  
+**ツール**：`pce_memory_feedback`  
 **Payload**：
 
 ```json
@@ -204,12 +204,12 @@ boundary_classes:
   "name": "pce-memory",
   "version": "0.1.0",
   "tools": [
-    { "name": "pce.memory.activate" },
-    { "name": "pce.memory.search" },
-    { "name": "pce.memory.upsert" },
-    { "name": "pce.memory.feedback" },
-    { "name": "pce.memory.boundary.validate" },
-    { "name": "pce.memory.policy.apply" }
+    { "name": "pce_memory_activate" },
+    { "name": "pce_memory_search" },
+    { "name": "pce_memory_upsert" },
+    { "name": "pce_memory_feedback" },
+    { "name": "pce_memory_boundary_validate" },
+    { "name": "pce_memory_policy_apply" }
   ]
 }
 ```
@@ -225,7 +225,7 @@ boundary_classes:
 ### policy.apply（最初だけ）
 
 ```bash
-curl -s -X POST http://localhost:8787/tools/pce.memory.policy.apply \
+curl -s -X POST http://localhost:8787/tools/pce_memory_policy_apply \
  -H "Authorization: Bearer $PCE_TOKEN" -H 'Content-Type: application/json' \
  -d @<(cat <<'JSON'
 {"yaml":"$(python3 - <<'PY'
@@ -240,7 +240,7 @@ JSON
 ### upsert（既知の前提を 2 件登録）
 
 ```bash
-curl -s -X POST http://localhost:8787/tools/pce.memory.upsert \
+curl -s -X POST http://localhost:8787/tools/pce_memory_upsert \
  -H "Authorization: Bearer $PCE_TOKEN" -H 'Content-Type: application/json' \
  -d '{
   "text":"解約APIは POST /subscriptions/{id}/cancel（非同期・冪等）",
@@ -251,7 +251,7 @@ curl -s -X POST http://localhost:8787/tools/pce.memory.upsert \
 ```
 
 ```bash
-curl -s -X POST http://localhost:8787/tools/pce.memory.upsert \
+curl -s -X POST http://localhost:8787/tools/pce_memory_upsert \
  -H "Authorization: Bearer $PCE_TOKEN" -H 'Content-Type: application/json' \
  -d '{
   "text":"Stripe webhook は 10 分の時刻ドリフトを許容",
@@ -264,7 +264,7 @@ curl -s -X POST http://localhost:8787/tools/pce.memory.upsert \
 ### activate（AC を構成し、前提をまとめて取得）
 
 ```bash
-curl -s -X POST http://localhost:8787/tools/pce.memory.activate \
+curl -s -X POST http://localhost:8787/tools/pce_memory_activate \
  -H "Authorization: Bearer $PCE_TOKEN" -H 'Content-Type: application/json' \
  -d '{"q":"解約/返金 仕様","scope":["project"],"allow":["answer:task"],"top_k":12}'
 ```
@@ -272,7 +272,7 @@ curl -s -X POST http://localhost:8787/tools/pce.memory.activate \
 ### boundary.validate（生成前の境界チェック＆マスク）
 
 ```bash
-curl -s -X POST http://localhost:8787/tools/pce.memory.boundary.validate \
+curl -s -X POST http://localhost:8787/tools/pce_memory_boundary_validate \
  -H "Authorization: Bearer $PCE_TOKEN" -H 'Content-Type: application/json' \
  -d '{"payload":"連絡は ryo@example.com へ","allow":["answer:task"],"scope":"project"}'
 ```
@@ -280,7 +280,7 @@ curl -s -X POST http://localhost:8787/tools/pce.memory.boundary.validate \
 ### feedback（採用/棄却を学習）
 
 ```bash
-curl -s -X POST http://localhost:8787/tools/pce.memory.feedback \
+curl -s -X POST http://localhost:8787/tools/pce_memory_feedback \
  -H "Authorization: Bearer $PCE_TOKEN" -H 'Content-Type: application/json' \
  -d '{"claim_id":"clm_7k","signal":"helpful","score":1.0}'
 ```

--- a/docs/pce-memory-vision.ja.md
+++ b/docs/pce-memory-vision.ja.md
@@ -90,21 +90,21 @@
 
 | Tool 名                        | 入力（req）                                                                    | 出力（resp）                                     | 目的                                      |
 | ------------------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------ | ----------------------------------------- | -------------------- | -------------- | ----------------------- |
-| `pce.memory.search`            | `{ query, top_k?, scope?, allow? }`                                            | `[{ claim, scores, evidences, policy_version }]` | 既知の前提・規約・禁止事項を想起          |
-| `pce.memory.activate`          | `{ q, scope?, allow? }`                                                        | `{ active_context_id, claims[] }`                | LCP から AC を構成（r 関数）              |
-| `pce.memory.upsert`            | `{ text, kind?, scope?, boundary_class?, entities?, relations?, provenance? }` | `{ id }`                                         | 重要断片の登録（Observation/Claim/Graph） |
-| `pce.memory.feedback`          | `{ claim_id, signal: helpful                                                   | harmful                                          | outdated                                  | duplicate, score? }` | `{ ok: true }` | Critic による評価ループ |
-| `pce.memory.boundary.validate` | `{ payload, allow?, scope? }`                                                  | `{ allowed, reason, redacted? }`                 | 生成前の境界チェック／Redact-before-Send  |
-| `pce.memory.policy.apply`      | `{ yaml }`                                                                     | `{ version }`                                    | ポリシー適用（不変量・用途タグ）          |
+| `pce_memory_search`            | `{ query, top_k?, scope?, allow? }`                                            | `[{ claim, scores, evidences, policy_version }]` | 既知の前提・規約・禁止事項を想起          |
+| `pce_memory_activate`          | `{ q, scope?, allow? }`                                                        | `{ active_context_id, claims[] }`                | LCP から AC を構成（r 関数）              |
+| `pce_memory_upsert`            | `{ text, kind?, scope?, boundary_class?, entities?, relations?, provenance? }` | `{ id }`                                         | 重要断片の登録（Observation/Claim/Graph） |
+| `pce_memory_feedback`          | `{ claim_id, signal: helpful                                                   | harmful                                          | outdated                                  | duplicate, score? }` | `{ ok: true }` | Critic による評価ループ |
+| `pce_memory_boundary_validate` | `{ payload, allow?, scope? }`                                                  | `{ allowed, reason, redacted? }`                 | 生成前の境界チェック／Redact-before-Send  |
+| `pce_memory_policy_apply`      | `{ yaml }`                                                                     | `{ version }`                                    | ポリシー適用（不変量・用途タグ）          |
 
 > すべてのツールは **Provenance** と **policy_version** をレスポンスに含め、監査可能性を担保する。
 
 ### 代表フロー（エージェント側）
 
-1. **Activation**：`pce.memory.activate` で AC を取得し、プロンプト先頭に貼る（前提注入）。
-2. **Generation**：候補案を生成する前に `pce.memory.boundary.validate` でチェック（必要なら redact）。
-3. **Upsert**：決定事項や設計の根拠を `pce.memory.upsert` で保存。由来（commit/URL）を必須に。
-4. **Feedback**：採用/棄却結果を `pce.memory.feedback` で返し、次回の再ランクに反映。
+1. **Activation**：`pce_memory_activate` で AC を取得し、プロンプト先頭に貼る（前提注入）。
+2. **Generation**：候補案を生成する前に `pce_memory_boundary_validate` でチェック（必要なら redact）。
+3. **Upsert**：決定事項や設計の根拠を `pce_memory_upsert` で保存。由来（commit/URL）を必須に。
+4. **Feedback**：採用/棄却結果を `pce_memory_feedback` で返し、次回の再ランクに反映。
 
 ### AC 生成関数 r の骨子（擬似）
 

--- a/docs/pce-memory-vision.md
+++ b/docs/pce-memory-vision.md
@@ -90,21 +90,21 @@
 
 | Tool Name                      | Input (req)                                                                    | Output (resp)                                    | Purpose                                                |
 | ------------------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------ | ------------------------------------------------------ | -------------------- | -------------- | -------------------------- |
-| `pce.memory.search`            | `{ query, top_k?, scope?, allow? }`                                            | `[{ claim, scores, evidences, policy_version }]` | Recall known prerequisites, conventions, prohibitions  |
-| `pce.memory.activate`          | `{ q, scope?, allow? }`                                                        | `{ active_context_id, claims[] }`                | Compose AC from LCP (r function)                       |
-| `pce.memory.upsert`            | `{ text, kind?, scope?, boundary_class?, entities?, relations?, provenance? }` | `{ id }`                                         | Register important fragments (Observation/Claim/Graph) |
-| `pce.memory.feedback`          | `{ claim_id, signal: helpful                                                   | harmful                                          | outdated                                               | duplicate, score? }` | `{ ok: true }` | Evaluation loop via Critic |
-| `pce.memory.boundary.validate` | `{ payload, allow?, scope? }`                                                  | `{ allowed, reason, redacted? }`                 | Boundary check before generation / Redact-before-Send  |
-| `pce.memory.policy.apply`      | `{ yaml }`                                                                     | `{ version }`                                    | Apply policy (invariants, purpose tags)                |
+| `pce_memory_search`            | `{ query, top_k?, scope?, allow? }`                                            | `[{ claim, scores, evidences, policy_version }]` | Recall known prerequisites, conventions, prohibitions  |
+| `pce_memory_activate`          | `{ q, scope?, allow? }`                                                        | `{ active_context_id, claims[] }`                | Compose AC from LCP (r function)                       |
+| `pce_memory_upsert`            | `{ text, kind?, scope?, boundary_class?, entities?, relations?, provenance? }` | `{ id }`                                         | Register important fragments (Observation/Claim/Graph) |
+| `pce_memory_feedback`          | `{ claim_id, signal: helpful                                                   | harmful                                          | outdated                                               | duplicate, score? }` | `{ ok: true }` | Evaluation loop via Critic |
+| `pce_memory_boundary_validate` | `{ payload, allow?, scope? }`                                                  | `{ allowed, reason, redacted? }`                 | Boundary check before generation / Redact-before-Send  |
+| `pce_memory_policy_apply`      | `{ yaml }`                                                                     | `{ version }`                                    | Apply policy (invariants, purpose tags)                |
 
 > All tools include **Provenance** and **policy_version** in responses to ensure auditability.
 
 ### Representative Flow (Agent Side)
 
-1. **Activation**: Get AC via `pce.memory.activate` and attach to prompt header (prerequisite injection).
-2. **Generation**: Check with `pce.memory.boundary.validate` before generating candidates (redact if needed).
-3. **Upsert**: Save decisions and design rationale via `pce.memory.upsert`. Provenance (commit/URL) mandatory.
-4. **Feedback**: Return adoption/rejection results via `pce.memory.feedback` for next re-ranking.
+1. **Activation**: Get AC via `pce_memory_activate` and attach to prompt header (prerequisite injection).
+2. **Generation**: Check with `pce_memory_boundary_validate` before generating candidates (redact if needed).
+3. **Upsert**: Save decisions and design rationale via `pce_memory_upsert`. Provenance (commit/URL) mandatory.
+4. **Feedback**: Return adoption/rejection results via `pce_memory_feedback` for next re-ranking.
 
 ### AC Generation Function r Outline (Pseudo)
 

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -28,11 +28,11 @@
 | `logs`              | `apps/pce-memory/src/store/logs.ts`          | `AuditLog`, `appendLog()`, `recordAudit()`, `AuditFileRecord`       |
 | `rateState`         | `apps/pce-memory/src/store/rate.ts`          | `initRateState()`, `checkAndConsume()`, `setRate()`, `resetRates()` |
 | `critic`            | `apps/pce-memory/src/store/critic.ts`        | `updateCritic()`                                                    |
-| `Upsert`            | `apps/pce-memory/src/index.ts`               | `pce.memory.upsert` handler                                         |
-| `Activate`          | `apps/pce-memory/src/index.ts`               | `pce.memory.activate` handler                                       |
-| `BoundaryValidate`  | `apps/pce-memory/src/index.ts`               | `pce.memory.boundary.validate` handler                              |
-| `Feedback`          | `apps/pce-memory/src/index.ts`               | `pce.memory.feedback` handler                                       |
-| `ApplyPolicy`       | `apps/pce-memory/src/index.ts`               | `pce.memory.policy.apply` handler, `applyPolicy()`                  |
+| `Upsert`            | `apps/pce-memory/src/index.ts`               | `pce_memory_upsert` handler                                         |
+| `Activate`          | `apps/pce-memory/src/index.ts`               | `pce_memory_activate` handler                                       |
+| `BoundaryValidate`  | `apps/pce-memory/src/index.ts`               | `pce_memory_boundary_validate` handler                              |
+| `Feedback`          | `apps/pce-memory/src/index.ts`               | `pce_memory_feedback` handler                                       |
+| `ApplyPolicy`       | `apps/pce-memory/src/index.ts`               | `pce_memory_policy_apply` handler, `applyPolicy()`                  |
 | `RefillTick`        | `apps/pce-memory/src/store/rate.ts`          | 時間窓リセット: `checkAndConsume()` 内 `resetNeeded` ロジック       |
 | DB初期化            | `apps/pce-memory/src/db/connection.ts`       | `initDb()`, `initSchema()`, `getConnection()`                       |
 | 環境設定            | `apps/pce-memory/src/config/env.ts`          | `loadEnv()`, `Env`                                                  |

--- a/packages/pce-sdk-ts/README.md
+++ b/packages/pce-sdk-ts/README.md
@@ -26,7 +26,7 @@ pnpm add @pce/sdk-ts
 
 MCPクライアント（例: `@modelcontextprotocol/sdk`）からは、以下のツール引数で呼び出せます。
 
-### `pce.memory.observe`
+### `pce_memory_observe`
 
 ```json
 {
@@ -45,7 +45,7 @@ Notes:
 
 - `effective_boundary_class` / `warnings` が返る場合があります（例: secret検知時は保存・抽出がスキップされる）。
 
-### `pce.memory.activate`
+### `pce_memory_activate`
 
 ```json
 {
@@ -58,13 +58,13 @@ Notes:
 
 ## Supported Tools
 
-- `pce.memory.policy.apply` - ポリシー適用
-- `pce.memory.observe` - 観察の記録（短期TTL）
-- `pce.memory.upsert` - Claim登録
-- `pce.memory.activate` - Active Contextの構成
-- `pce.memory.boundary.validate` - 境界チェック
-- `pce.memory.feedback` - フィードバック送信
-- `pce.memory.state` - 状態取得
+- `pce_memory_policy_apply` - ポリシー適用
+- `pce_memory_observe` - 観察の記録（短期TTL）
+- `pce_memory_upsert` - Claim登録
+- `pce_memory_activate` - Active Contextの構成
+- `pce_memory_boundary_validate` - 境界チェック
+- `pce_memory_feedback` - フィードバック送信
+- `pce_memory_state` - 状態取得
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

- **BREAKING CHANGE**: 全14個のMCPツール名をドット区切り（`.`）からアンダースコア区切り（`_`）に変更
- MCP コミュニティ標準（snake_case）に準拠（[SEP-986](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/986)参照）

### 変更されたツール名

| 旧名 | 新名 |
|------|------|
| `pce.memory.policy.apply` | `pce_memory_policy_apply` |
| `pce.memory.observe` | `pce_memory_observe` |
| `pce.memory.upsert` | `pce_memory_upsert` |
| `pce.memory.activate` | `pce_memory_activate` |
| `pce.memory.boundary.validate` | `pce_memory_boundary_validate` |
| `pce.memory.feedback` | `pce_memory_feedback` |
| `pce.memory.state` | `pce_memory_state` |
| `pce.memory.upsert.entity` | `pce_memory_upsert_entity` |
| `pce.memory.upsert.relation` | `pce_memory_upsert_relation` |
| `pce.memory.query.entity` | `pce_memory_query_entity` |
| `pce.memory.query.relation` | `pce_memory_query_relation` |
| `pce.memory.sync.push` | `pce_memory_sync_push` |
| `pce.memory.sync.pull` | `pce_memory_sync_pull` |
| `pce.memory.sync.status` | `pce_memory_sync_status` |

## 変更内容

- `handlers.ts`: ツール定義とディスパッチャのツール名変更
- テストファイル: 6ファイルのツール名参照更新
- ドキュメント: 12ファイルのツール名参照更新
- CHANGELOG: 破壊的変更として記載

## Test plan

- [x] `pnpm build` - 成功
- [x] `pnpm test` - 653 tests passed
- [x] `pnpm lint` - エラーなし
- [x] Critical Review実施（変更漏れ2箇所を修正）

🤖 Generated with [Claude Code](https://claude.com/claude-code)